### PR TITLE
New version of slice and template update according to it

### DIFF
--- a/remotetypes/remoteset.py
+++ b/remotetypes/remoteset.py
@@ -11,9 +11,14 @@ from remotetypes.customset import StringSet
 class RemoteSet(rt.RSet):
     """Implementation of the remote interface RSet."""
 
-    def __init__(self) -> None:
+    def __init__(self, identifier) -> None:
         """Initialise a RemoteSet with an empty StringSet."""
         self._storage_ = StringSet()
+        self.id_ = identifier
+
+    def identifier(self, current: Optional[Ice.Current] = None) -> str:
+        """Return the identifier of the object."""
+        return self.id_
 
     def remove(self, item: str, current: Optional[Ice.Current] = None) -> None:
         """Remove an item from the StringSet if added. Else, raise a remote exception."""

--- a/remotetypes/remotetypes.ice
+++ b/remotetypes/remotetypes.ice
@@ -14,6 +14,7 @@ module RemoteTypes {
     };
 
     interface RType {
+        idempotent string identifier();
         void remove(string item) throws KeyError;
         idempotent int length();
         idempotent bool contains(string item);


### PR DESCRIPTION
New version of the slice file adding the `identifier` method to the `RType` interface.

It will make possible to create a remote object with empty identifier from the `Factory.get` and then reuse it.

In the previous version the identifier cannot be retrieved when it is not provided, so that object can be used only one time.